### PR TITLE
Update MIOpen, ROCfft, and clean a few things

### DIFF
--- a/pkgs/all-packages.nix
+++ b/pkgs/all-packages.nix
@@ -31,7 +31,7 @@ with pkgs;
   rocm-cmake = callPackage ./development/tools/build-managers/rocm-cmake {};
   rocminfo = callPackage ./development/tools/rocminfo.nix {
     inherit (self) rocm-cmake rocm-runtime;
-    defaultTargets = config.rocmTargets or ["gfx803" "gfx900" "gfx906"];
+    defaultTargets = config.rocmTargets or [ "gfx803" "gfx900" "gfx906" ];
   };
 
   rocm-device-libs = callPackage ./development/libraries/rocm-device-libs {
@@ -119,17 +119,17 @@ with pkgs;
     inherit (self.llvmPackages_rocm) clang;
   };
 
-  # # Currently broken
-  miopen-cl = callPackage ./development/libraries/miopen {
-    inherit (self) rocm-cmake rocm-opencl-runtime rocm-runtime
-                   clang-ocl miopengemm rocblas;
+  miopen-hip = callPackage ./development/libraries/miopen {
+    inherit (self) rocm-cmake rocm-runtime miopengemm rocblas clang-ocl;
     inherit (self.llvmPackages_rocm) clang clang-unwrapped;
     hip = self.hip-clang;
     comgr = self.rocm-comgr;
   };
 
-  miopen-hip = self.miopen-cl.override {
-    useHip = true;
+  # Broken
+  miopen-cl = self.miopen-cl.override {
+    use_ocl = true;
+    inherit rocm-opencl-runtime; 
   };
 
   rocfft = callPackage ./development/libraries/rocfft {

--- a/pkgs/development/libraries/hipcub/default.nix
+++ b/pkgs/development/libraries/hipcub/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DCMAKE_CXX_COMPILER=hipcc"
     "-DCMAKE_INSTALL_INCLUDEDIR=include"
-    "-DAMDGPU_TARGETS=${lib.strings.concatStringsSep ";" (config.rocmTargets or ["gfx803" "gfx900" "gfx906"])}"
+    "-DAMDGPU_TARGETS=${lib.strings.concatStringsSep ";" (config.rocmTargets or [ "gfx803" "gfx900" "gfx906" ])}"
     "-DBUILD_TEST=${if doCheck then "YES" else "NO"}"
   ];
 

--- a/pkgs/development/libraries/hipsparse/default.nix
+++ b/pkgs/development/libraries/hipsparse/default.nix
@@ -1,22 +1,30 @@
-{stdenv, fetchFromGitHub, cmake, rocsparse, hip, rocm-runtime, rocm-cmake, comgr, gtest
+{stdenv, fetchFromGitHub, cmake, gfortran, rocsparse, rocprim, hip, rocm-runtime, rocm-cmake, comgr
 
 # Tests are broken as they require downloading and pre-processing
 # several files
-# , doCheck ? true
+, doCheck ? false, gtest ? null
 }:
-let doCheck = false; in
+
+assert doCheck -> gtest != null;
+
 stdenv.mkDerivation rec {
   pname = "hipsparse";
-  version = "3.5.0";
+  version = "3.8.0";
   src = fetchFromGitHub {
     owner = "ROCmSoftwarePlatform";
     repo = "hipSPARSE";
     rev = "rocm-${version}";
-    sha256 = "0zyvvkhyr6cn6dcyi7fh2q5f1w0afcmvzjdalq0bjad77psy0sb2";
+    sha256 = "0h5q6f9f9vhr05aryxx5iapkd2n2zhsv1w09lm3q6pnpy87y6kd3";
   };
 
-  nativeBuildInputs = [ cmake rocm-cmake ] ++ stdenv.lib.optional doCheck gtest;
-  buildInputs = [ rocsparse hip rocm-runtime comgr ];
+  inherit doCheck;
+
+  nativeBuildInputs = [ cmake rocm-cmake ];
+  
+  buildInputs = [ gfortran rocsparse rocprim hip rocm-runtime comgr ];
+
+  checkInputs = [ gtest ];
+  
   cmakeFlags = [
     "-DCMAKE_INSTALL_INCLUDEDIR=include"
     "-DCMAKE_CXX_COMPILER=${hip}/bin/hipcc"

--- a/pkgs/development/libraries/miopen/default.nix
+++ b/pkgs/development/libraries/miopen/default.nix
@@ -1,34 +1,40 @@
-{ stdenv, fetchFromGitHub, cmake, pkgconfig, half, openssl, boost, sqlite, bzip2
-, rocm-cmake, rocm-opencl-runtime, rocm-runtime, clang, clang-unwrapped, clang-ocl, miopengemm, rocblas
-, comgr, useHip ? false, hip }:
-assert useHip -> hip != null;
+{ stdenv, fetchFromGitHub, cmake, config, lib, pkgconfig, half, openssl, boost, sqlite, bzip2
+, rocm-cmake, rocm-runtime, clang, clang-unwrapped, hip, miopengemm, rocblas, comgr, clang-ocl
+, use_ocl ? false, rocm-opencl-runtime ? null
+}:
+
+assert use_ocl -> rocm-opencl-runtime != null;
+
 stdenv.mkDerivation rec {
   name = "miopen";
-  version = "2.4.0";
+  version = "2.7.0";
   src = fetchFromGitHub {
     owner = "ROCmSoftwarePlatform";
     repo = "MIOpen";
     rev = "${version}";
-    sha256 = "1qs4zxqza4bg1055fnbyhrvyskbg8f4nc6adlrn6yqq2xin50jsz";
+    sha256 = "1hvjqg1pn52k3zyxi0wlrabi874g5n5pshdnfq5wmyaqr2vy694p";
   };
+
   nativeBuildInputs = [ cmake pkgconfig rocm-cmake ];
-  buildInputs = [ rocm-runtime half openssl boost rocblas miopengemm comgr sqlite bzip2 ]
-    ++ (if useHip then [ hip ] else [rocm-opencl-runtime clang-ocl hip]);
+
+  buildInputs = [ rocm-runtime half openssl boost rocblas miopengemm comgr sqlite bzip2 clang-ocl hip ]
+    ++ lib.optionals use_ocl [ rocm-opencl-runtime ];
 
   cmakeFlags = [
-    "-DCMAKE_PREFIX_PATH=${hip};${clang-ocl}"
+    "-DCMAKE_PREFIX_PATH=${if use_ocl then "${hip};${clang-ocl}" else "${hip}"}"
     "-DCMAKE_INSTALL_INCLUDEDIR=include"
     "-DMIOPEN_USE_ROCBLAS=ON"
     "-DBoost_USE_STATIC_LIBS=OFF"
     "-DMIOPEN_USE_MIOPENGEMM=ON"
     "-DMIOPEN_AMDGCN_ASSEMBLER_PATH=${clang}/bin"
     "-DMIOPEN_OFFLOADBUNDLER_BIN=${clang-unwrapped}/bin/clang-offload-bundler"
-  ] ++ (if useHip
+  ] ++ (if !use_ocl
         then [ # "-DCMAKE_CXX_COMPILER=${clang}/bin/clang++"
                # "-DCMAKE_C_COMPILER=${clang}/bin/clang"
                "-DCMAKE_CXX_COMPILER=${hip}/bin/hipcc"
                "-DCMAKE_C_COMPILER=${hip}/bin/hipcc"
                "-DMIOPEN_BACKEND=HIP"
+               "-DAMDGPU_TARGETS=${lib.strings.concatStringsSep ";" (config.rocmTargets or [ "gfx803" "gfx900" "gfx906" ])}"
                # "-DENABLE_HIP_WORKAROUNDS=YES"
         ]
         else [ "-DMIOPEN_BACKEND=OpenCL"
@@ -36,7 +42,9 @@ stdenv.mkDerivation rec {
                "-DCMAKE_C_COMPILER=${clang}/bin/clang"
                # "-DOPENCL_INCLUDE_DIRS=${rocm-opencl-runtime}/include/opencl2.2"
                # "-DOPENCL_LIB_DIRS=${rocm-opencl-runtime}/lib"
-  ]);
+        ]
+  );
+  
   patchPhase = ''
     sed -e 's,cmake_minimum_required( VERSION 2.8.12 ),cmake_minimum_required( VERSION 3.10 ),' \
         -e 's,\(set( MIOPEN_INSTALL_DIR\).*,\1 ''${CMAKE_INSTALL_PREFIX}),' \

--- a/pkgs/development/libraries/miopengemm/default.nix
+++ b/pkgs/development/libraries/miopengemm/default.nix
@@ -1,5 +1,6 @@
 { stdenv, fetchFromGitHub, cmake
 , rocm-cmake, rocm-opencl-runtime, clang }:
+
 stdenv.mkDerivation rec {
   name = "miopengemm";
   version = "20200109";
@@ -9,8 +10,11 @@ stdenv.mkDerivation rec {
     rev = "b51a12523676451bf38bfcf0506a0745e80ac64f";
     sha256 = "065gwnjspf6zs6n2pjw2hxjmp9m47q9jngr5snqmh1gv9qvj1b3i";
   };
+  
   nativeBuildInputs = [ cmake rocm-cmake ];
+  
   buildInputs = [ rocm-opencl-runtime ];
+  
   cmakeFlags = [
     "-DCMAKE_CXX_COMPILER=${clang}/bin/clang++"
     "-DOPENCL_INCLUDE_DIRS=${rocm-opencl-runtime}/include"

--- a/pkgs/development/libraries/rocblas/default.nix
+++ b/pkgs/development/libraries/rocblas/default.nix
@@ -40,7 +40,7 @@ in stdenv.mkDerivation rec {
     "-DCMAKE_INSTALL_INCLUDEDIR=include"
     "-DBUILD_WITH_TENSILE=${if useTensile then "ON" else "OFF"}"
     "-DTensile_COMPILER=hipcc"
-    "-DAMDGPU_TARGETS=${lib.strings.concatStringsSep ";" (config.rocmTargets or ["gfx803" "gfx900" "gfx906"])}"
+    "-DAMDGPU_TARGETS=${lib.strings.concatStringsSep ";" (config.rocmTargets or [ "gfx803" "gfx900" "gfx906" ])}"
   ] ++ stdenv.lib.optionals doCheck [
     "-DBUILD_CLIENTS_SAMPLES=NO"
     "-DBUILD_CLIENTS_TESTS=YES"

--- a/pkgs/development/libraries/rocfft/default.nix
+++ b/pkgs/development/libraries/rocfft/default.nix
@@ -1,31 +1,42 @@
-{ stdenv, fetchFromGitHub, fetchpatch, cmake, pkgconfig
+{ stdenv, fetchFromGitHub, fetchpatch, lib, config, cmake, pkgconfig
 , rocm-runtime, rocminfo, clang, hip, rocm-cmake, comgr
-, doCheck ? false
-, boost, gtest, fftw, fftwFloat }:
+, boost 
+, doCheck ? false, gtest ? null, fftw ? null, fftwFloat ? null 
+}:
+
+assert doCheck -> gtest != null
+               && fftw != null
+               && fftwFloat != null;
+
 stdenv.mkDerivation rec {
   name = "rocFFT";
-  version = "3.5.0";
+  version = "3.8.0";
   src = fetchFromGitHub {
     owner = "ROCmSoftwarePlatform";
     repo = "rocFFT";
-    rev = "${version}";
-    sha256 = "03cxfx40gg817pm1lknpi7vma17wfqggprxd8vz8hlipxd3cisng";
+    rev = "rocm-${version}";
+    sha256 = "129jvg3jl723wixfnw0w3ljjgjz49jkdwcp80layzlh2xifqm880";
   };
 
   # Building this package is very RAM intensive: individual clang
   # processes use over 6GB of RAM.
-  enableParallelBuilding = false;
-  CXXFLAGS = "-D__HIP_PLATFORM_HCC__ -D__HIP__";
+  #enableParallelBuilding = false;
+  
+  CXXFLAGS = "-D__HIP_PLATFORM_HCC__ -D__HIP__ ";
 
   nativeBuildInputs = [ cmake rocm-cmake pkgconfig rocminfo ];
-  buildInputs = [ hip rocm-runtime boost comgr ]
-    ++ stdenv.lib.optionals doCheck [ gtest fftwFloat fftw ];
+  
+  buildInputs = [ hip rocm-runtime boost comgr ];
+  
+  checkInputs = [ gtest fftwFloat fftw ];
+  
   cmakeFlags = [
-    # "-DUSE_HIP_CLANG=YES"
+    "-DUSE_HIP_CLANG=ON"
     "-DCMAKE_CXX_COMPILER=${hip}/bin/hipcc"
     # "-DHSA_HEADER=${rocm-runtime}/include"
     # "-DHSA_LIBRARY=${rocm-runtime}/lib/libhsa-runtime64.so"
     "-DCMAKE_INSTALL_INCLUDEDIR=include"
+    "-DAMDGPU_TARGETS=${lib.strings.concatStringsSep ";" (config.rocmTargets or [ "gfx803" "gfx900" "gfx906" ])}"
   ] ++ stdenv.lib.optionals doCheck [
     "-DBUILD_CLIENTS_TESTS=ON"
     "-DBUILD_CLIENTS_BENCHMARKS=ON"

--- a/pkgs/development/libraries/rocprim/default.nix
+++ b/pkgs/development/libraries/rocprim/default.nix
@@ -26,9 +26,8 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DCMAKE_CXX_COMPILER=hipcc"
     "-DCMAKE_INSTALL_INCLUDEDIR=include"
-    "-DAMDGPU_TARGETS=${lib.strings.concatStringsSep ";" (config.rocmTargets or ["gfx803" "gfx900" "gfx906"])}"
+    "-DAMDGPU_TARGETS=${lib.strings.concatStringsSep ";" (config.rocmTargets or [ "gfx803" "gfx900" "gfx906" ])}"
     "-DBUILD_TEST=${if doCheck then "YES" else "NO"}"
-    "${if doCheck then "-DAMDGPU_TEST_TARGETS=${lib.strings.concatStringsSep ";" (config.rocmTargets or ["gfx803" "gfx900" "gfx906"])}" else ""}"
   ];
   
   patchPhase = ''

--- a/pkgs/development/libraries/rocrand/default.nix
+++ b/pkgs/development/libraries/rocrand/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     "-DHIP_PATH=${hip}"
     "-DCMAKE_CXX_COMPILER=${hip}/bin/hipcc"
     "-DCMAKE_INSTALL_INCLUDEDIR=include"
-    "-DAMDGPU_TARGETS=${lib.strings.concatStringsSep ";" (config.rocmTargets or ["gfx803" "gfx900" "gfx906"])}"
+    "-DAMDGPU_TARGETS=${lib.strings.concatStringsSep ";" (config.rocmTargets or [ "gfx803" "gfx900" "gfx906" ])}"
   ] ++ (let flag = if doCheck then "ON" else "OFF";
         in [ "-DBUILD_TEST=${flag} -DBUILD_BENCHMARK=${flag}" ]);
         

--- a/pkgs/development/libraries/rocsparse/default.nix
+++ b/pkgs/development/libraries/rocsparse/default.nix
@@ -1,13 +1,21 @@
-{stdenv, fetchFromGitHub, fetchpatch, cmake, rocm-cmake, hip, rocprim, hipcub, comgr}:
+{ stdenv, fetchFromGitHub, fetchpatch, lib, config, cmake, gfortran
+, rocm-cmake, hip, rocprim, hipcub, comgr 
+, doCheck ? false, gtest ? null
+}:
+
+assert doCheck -> gtest != null;
+
 stdenv.mkDerivation rec {
   name = "rocsparse";
-  version = "3.5.0";
+  version = "3.8.0";
   src = fetchFromGitHub {
     owner = "ROCmSoftwarePlatform";
     repo = "rocSPARSE";
     rev = "rocm-${version}";
-    sha256 = "0k86x6jvnn7yi5cg12cc00liwhbg2zrr6axvcrjhg2k83vn6mhjz";
+    sha256 = "144i9y7lcawixsfc9d9bbrx4w2jr6vnamx12jkyms7y1gln75qpf";
   };
+
+  inherit doCheck;
 
   postPatch = ''
     sed -e '/find_package(Git REQUIRED)/d' \
@@ -18,13 +26,22 @@ stdenv.mkDerivation rec {
     sed 's/\(cmake_minimum_required.*\)$/\1\nproject(rocsparse LANGUAGES CXX)/' -i CMakeLists.txt
   '';
 
+  nativeBuildInputs = [ cmake rocm-cmake ];
+  
+  buildInputs = [ hip rocprim hipcub comgr gfortran ];
+
+  checkInputs = [ gtest ];
+
   cmakeFlags = [
     "-DCMAKE_CXX_COMPILER=hipcc"
     "-DCMAKE_INSTALL_INCLUDEDIR=include"
-    "-DBUILD_TEST=NO"
+    "-DBUILD_TEST=${if doCheck then "ON" else "OFF"}"
     "-DCMAKE_PREFIX_PATH=${rocm-cmake}/share/rocm/cmake"
+    "-DAMDGPU_TARGETS=${lib.strings.concatStringsSep ";" (config.rocmTargets or [ "gfx803" "gfx900" "gfx906" ])}"
   ];
-  nativeBuildInputs = [ cmake rocm-cmake ];
-  buildInputs = [ hip rocprim hipcub comgr ];
 
+  checkPhase = ''
+    # Test phase does not work. 
+    #./clients/staging/rocsparse-test
+  '';
 }


### PR DESCRIPTION
I haven't tried to build the OpenCL backend and suspect it's broken. This does build the HIP backend though. One possible problem I see is the current `CMAKE_PREFIX_PATH` might need more added to it. I also don't quite know why I needed the `clang-ocl` derivation for the HIP backend, but it complained without it. I recommend you look this over with some scrutiny. Also, we really should figure out how to test this derivation, since it's a big one.